### PR TITLE
Add HiDPI support

### DIFF
--- a/Demo/Source/UMain.pas
+++ b/Demo/Source/UMain.pas
@@ -28,12 +28,14 @@ unit UMain;
 
 interface
 
+{$INCLUDE IconFontsImageList.inc}
+
 uses
   Windows, Messages, SysUtils, Variants, Classes, Graphics,
   Controls, Forms, Dialogs, ImgList,
   StdCtrls, Buttons, StdActns,
   ActnList, ExtCtrls, ComCtrls, ToolWin,
-  Spin, IconFontsImageList;
+  Spin, IconFontsImageList, System.Actions, System.ImageList;
 
 type
   TMainForm = class(TForm)
@@ -77,6 +79,7 @@ type
     procedure ReplaceBitBtnClick(Sender: TObject);
     procedure DeleteIconActionExecute(Sender: TObject);
   private
+    procedure FormAfterMonitorDpiChanged(Sender: TObject; OldDPI, NewDPI: Integer);
     procedure UpdateButtons;
     procedure UpdateGUI;
     procedure UpdateListView;
@@ -169,6 +172,11 @@ begin
   end;
 end;
 
+procedure TMainForm.FormAfterMonitorDpiChanged(Sender: TObject; OldDPI, NewDPI: Integer);
+begin
+  UpdateGUI;
+end;
+
 procedure TMainForm.FormCreate(Sender: TObject);
 begin
   if Screen.Fonts.IndexOf('Material Design Icons') = -1 then
@@ -177,6 +185,10 @@ begin
   
   TrackBar.Position := IconFontsImageList.Height;
   TrackBarChange(TrackBar);
+
+  {$IF Defined(HiDPISupport)}
+  OnAfterMonitorDpiChanged := FormAfterMonitorDpiChanged;
+  {$ENDIF}
 end;
 
 procedure TMainForm.IconFontsImageListChange(Sender: TObject);

--- a/Source/IconFontsImageList.inc
+++ b/Source/IconFontsImageList.inc
@@ -1,0 +1,20 @@
+//StoreBitmap option introduced in Delphi 10.3 Rio
+{$IF Defined(VER210) //Delphi 2010
+  or Defined(VER220) //Delphi XE
+  or Defined(VER230) //Delphi XE2
+  or Defined(VER240) //Delphi XE3
+  or Defined(VER250) //Delphi XE4
+  or Defined(VER260) //Delphi XE5
+  or Defined(VER270) //Delphi XE6
+  or Defined(VER280) //Delphi XE7
+  or Defined(VER290) //Delphi XE8
+  or Defined(VER300) //Delphi 10 Seattle
+  or Defined(VER310) //Delphi 10.1 Berlin
+  or Defined(VER320) //Delphi 10.2 Tokyo
+  }
+  {$Define NeedStoreBitmapProperty}
+{$IFEND}
+
+{$IF Defined(VER330)}
+  {$Define HiDPISupport}
+{$IFEND}

--- a/Source/IconFontsUtils.pas
+++ b/Source/IconFontsUtils.pas
@@ -28,6 +28,8 @@ unit IconFontsUtils;
 
 interface
 
+{$INCLUDE IconFontsImageList.inc}
+
 uses
   Classes
   , ImgList


### PR DESCRIPTION
Hi Carlo,
with these changes your ImageList should support HiDPI. I added a new IconFontsImageList.inc file with all define plus a new one called *HiDPISupport*. The define is enabled if the package is compiled with Delphi Rio.

The image list has a new property *Scale* (true by default) that enable auto scaling of the images based on the DPI of the current monitor.